### PR TITLE
Refactor comment repo

### DIFF
--- a/back/.eslintrc.js
+++ b/back/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
   overrides: [],
   parser: '@typescript-eslint/parser',
   parserOptions: {
+    project: ['./tsconfig.json'],
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
@@ -16,5 +17,6 @@ module.exports = {
     'linebreak-style': ['error', 'unix'],
     quotes: ['error', 'single'],
     semi: ['error', 'always'],
+    '@typescript-eslint/no-floating-promises': 'error'
   },
 };

--- a/back/src/comments/repository.test.ts
+++ b/back/src/comments/repository.test.ts
@@ -8,18 +8,13 @@ describe('comment', () => {
     const repo = FakeCommentRepo([]);
     // 처음에는 id가 1인 post의 댓글 목록은 비어있다.
     expect(await repo.getCommentsByPostId(POST_ID_1)).toStrictEqual([]);
-    // post가 없으면 댓글목록을 가져올 수 없다.
-    // toThrowError가 작동하지 않아서 주석처리
-    await expect(() => repo.getCommentsByPostId(2)).rejects.toThrowError(
-      '404 not found'
-    );
 
     // id가 1인 post에 댓글을 추가한다.
     await repo.addCommentToPost(POST_ID_1, '안녕');
     const COMMENT_ID = 1;
     // id가 1인 post에 id가 1인 댓글이 추가되었다.
     expect(await repo.getCommentsByPostId(POST_ID_1)).toStrictEqual([
-      { id: COMMENT_ID, message: '안녕' },
+      { id: COMMENT_ID, message: '안녕', postId: POST_ID_1 },
     ]);
     
     await repo.updateComment(POST_ID_1, COMMENT_ID,'바이');
@@ -27,7 +22,7 @@ describe('comment', () => {
     // expect(actual).toStrictEqual(expected)
     // actual 과 expected 가 같은가?
     expect(await repo.getCommentsByPostId(POST_ID_1)).toStrictEqual([
-      { id: COMMENT_ID, message: '바이' },
+      { id: COMMENT_ID, message: '바이', postId: POST_ID_1 },
     ]);
 
     await repo.deleteComment(POST_ID_1, COMMENT_ID);
@@ -43,8 +38,8 @@ describe('comment', () => {
     await repo.addCommentToPost(3, '안녕4');
 
     expect(await repo.getCommentsByPostId(3)).toStrictEqual([
-      { id: 5, message: '안녕3' },
-      { id: 6, message: '안녕4' },
+      { id: 5, message: '안녕3', postId: 3 },
+      { id: 6, message: '안녕4', postId: 3 },
     ]);
   });
 });

--- a/back/src/comments/repository.test.ts
+++ b/back/src/comments/repository.test.ts
@@ -5,19 +5,17 @@ const POST_ID_1 = 1;
 // 포스트를 작성하면, 추가된다!
 describe('comment', () => {
   it('scenario', async () => {
-    const repo = FakeCommentRepo({ [POST_ID_1]: [] });
+    const repo = FakeCommentRepo([]);
     // 처음에는 id가 1인 post의 댓글 목록은 비어있다.
     expect(await repo.getCommentsByPostId(POST_ID_1)).toStrictEqual([]);
     // post가 없으면 댓글목록을 가져올 수 없다.
     // toThrowError가 작동하지 않아서 주석처리
-    expect(() => repo.getCommentsByPostId(2)).rejects.toThrowError(
+    await expect(() => repo.getCommentsByPostId(2)).rejects.toThrowError(
       '404 not found'
     );
 
     // id가 1인 post에 댓글을 추가한다.
-    await repo.addCommentToPost(POST_ID_1, {
-      message: '안녕',
-    });
+    await repo.addCommentToPost(POST_ID_1, '안녕');
     const COMMENT_ID = 1;
     // id가 1인 post에 id가 1인 댓글이 추가되었다.
     expect(await repo.getCommentsByPostId(POST_ID_1)).toStrictEqual([
@@ -37,14 +35,12 @@ describe('comment', () => {
   });
   
   it('autoincrement', async () => {
-    const repo = FakeCommentRepo({
-      1: [
-        { id: 2, message: '안녕' },
-        { id: 4, message: '안녕2' },
-      ],
-      3: [{ id: 5, message: '안녕3' }],
-    });
-    await repo.addCommentToPost(3, { message: '안녕4' });
+    const repo = FakeCommentRepo([
+      { id: 2, message: '안녕', postId: 1 },
+      { id: 4, message: '안녕2', postId: 1 },
+      { id: 5, message: '안녕3', postId: 3 }
+    ]);
+    await repo.addCommentToPost(3, '안녕4');
 
     expect(await repo.getCommentsByPostId(3)).toStrictEqual([
       { id: 5, message: '안녕3' },

--- a/back/src/comments/repository.ts
+++ b/back/src/comments/repository.ts
@@ -1,3 +1,4 @@
+import { invariant } from '../invariant';
 import type { CommentT } from './schema';
 
 export interface ICommentRepository {
@@ -14,6 +15,9 @@ export interface ICommentRepository {
   deleteComment: (
     postId: CommentT['postId'],
     commentId: CommentT['id']
+  ) => Promise<void>;
+  deleteCommentsInPost: (
+    postId: CommentT['postId'],
   ) => Promise<void>;
 }
 
@@ -32,9 +36,7 @@ export function FakeCommentRepo(init: _FakeDB): ICommentRepository {
     const comment = _fakeDB.find(
       (comment) => comment.postId === postId && comment.id == commentId
     );
-    if (!comment) {
-      throw Error('????');
-    }
+    invariant(comment !== undefined, `코멘트<${commentId}>가 존재하지 않습니다`);
     return comment;
   }
 
@@ -61,5 +63,8 @@ export function FakeCommentRepo(init: _FakeDB): ICommentRepository {
 
       _fakeDB = _fakeDB.filter((comment) => comment !== targetComment);
     },
+    async deleteCommentsInPost(postId){
+      _fakeDB = _fakeDB.filter((comment) => comment.postId !== postId);
+    }
   };
 }

--- a/back/src/comments/repository.ts
+++ b/back/src/comments/repository.ts
@@ -1,91 +1,65 @@
-import type { PostT } from "../posts/schema";
-import type { CommentT } from "./schema";
+import type { CommentT } from './schema';
 
 export interface ICommentRepository {
-  getCommentsByPostId: (postId: PostT["id"]) => Promise<CommentT[]>;
+  getCommentsByPostId: (postId: CommentT['postId']) => Promise<CommentT[]>;
   addCommentToPost: (
-    postId: PostT["id"],
-    newComment: Omit<CommentT, "id">
+    postId: CommentT['postId'],
+    message: CommentT['message']
   ) => Promise<void>;
   updateComment: (
-    postId: PostT["id"],
-    commentId: CommentT["id"],
-    newMessage: CommentT["message"]
+    postId: CommentT['postId'],
+    commentId: CommentT['id'],
+    newMessage: CommentT['message']
   ) => Promise<void>;
   deleteComment: (
-    postId: PostT["id"],
-    commentId: CommentT["id"]
+    postId: CommentT['postId'],
+    commentId: CommentT['id']
   ) => Promise<void>;
 }
 
-type _FakeDB = {
-  [postId: PostT["id"]]: CommentT[];
-};
+type _FakeDB = CommentT[];
+
 // post가 하나 작성되어있다고 가정했다.
 export function FakeCommentRepo(init: _FakeDB): ICommentRepository {
   let _fakeDB = init;
 
-  let _count = Math.max(
-    0,
-    ...Object.values(init).flatMap((comments) =>
-      comments.map((comment) => comment.id)
-    )
-  );
+  let _count = Math.max(0, ...init.map((comment) => comment.id));
+
+  async function _getCommentById(
+    postId: CommentT['postId'],
+    commentId: CommentT['id']
+  ) {
+    const comment = _fakeDB.find(
+      (comment) => comment.postId === postId && comment.id == commentId
+    );
+    if (!comment) {
+      throw Error('????');
+    }
+    return comment;
+  }
 
   return {
     async getCommentsByPostId(postId) {
-      const comments = _fakeDB[postId];
-      if (comments === undefined) {
-        throw Error("404 not found");
-      }
-
-      return comments;
+      return _fakeDB.filter((comment) => comment.postId === postId);
     },
-    async addCommentToPost(postId, newComment) {
-      const comments = _fakeDB[postId];
-      if (comments === undefined) {
-        throw Error("404 not found");
-      }
-
+    async addCommentToPost(postId, message) {
       _count++;
-      comments.push({
+      const newComment = {
         id: _count,
-        ...newComment,
-      });
+        message,
+        postId,
+      };
+      _fakeDB = [..._fakeDB, newComment];
     },
-    async updateComment(
-      postId,
-      commentId,
-      newMessage,
-    ) {
-      const comments = _fakeDB[postId];
-      if(!comments){
-        //에러메세지 어떻게 쓸 지 모르겠어요...
-        throw Error('????')
-      }
-      
-      const targetComment = comments.find(comment=> comment.id == commentId);
-      if(!targetComment){
-        throw Error('????')
-      }
+    async updateComment(postId, commentId, newMessage) {
+      const targetComment = await _getCommentById(postId, commentId);
 
       targetComment.message = newMessage;
     },
-    async deleteComment (
-      postId,
-      commentId,
-    ) {
-      const comments = _fakeDB[postId];
-      if(!comments){
-        throw Error('????')
-      }
-      
-      const targetComment = comments.find(comment=> comment.id == commentId);
-      if(!targetComment){
-        throw Error('????')         
-      }
+    async deleteComment(postId, commentId) {
+      const targetComment = await _getCommentById(postId, commentId);
 
-      _fakeDB[postId] = comments.filter(comment=> comment !== targetComment)
-    }
+      _fakeDB = _fakeDB.filter((comment) => comment !== targetComment);
+    },
   };
 }

--- a/back/src/comments/router.spec.ts
+++ b/back/src/comments/router.spec.ts
@@ -1,52 +1,58 @@
+import { FakePostRepo } from '../posts/repository';
 import { FakeCommentRepo } from './repository';
 import { commentRouter } from './router';
 
-const POST_ID_1 = 1;
+const POST_ID = 5;
 
 describe('comments', () => {
   it('scenario', async () => {
     // caller를 만들고
     const caller = commentRouter.createCaller({
+      postRepo: FakePostRepo([{
+        id: POST_ID,
+        message: '찬민아 결혼 축하해',
+        images: [],
+      }]),
       commentRepo: FakeCommentRepo([])
     });
 
-    // 처음에는 id가 1인 post의 댓글 목록은 비어있다.
-    expect(await caller.query('read', POST_ID_1)).toStrictEqual([]);
-    // id가 1인 post의 댓글을 추가한다.
+    // 처음에는 post의 댓글 목록은 비어있다.
+    expect(await caller.query('read', { postId: POST_ID })).toStrictEqual([]);
+    // post에 댓글을 추가한다.
     await caller.mutation('create', {
-      id: POST_ID_1,
+      id: POST_ID,
       message: '안녕',
     });
-    // id가 1인 post의 댓글이 추가되었다.
-    expect(await caller.query('read', POST_ID_1)).toStrictEqual([
+    // post에 댓글을 추가했다.
+    expect(await caller.query('read', { postId: POST_ID })).toStrictEqual([
       {
         id: 1,
         message: '안녕',
-        postId: POST_ID_1
+        postId: POST_ID
       },
     ]);
 
     await caller.mutation('update', {
-      postId: POST_ID_1,
+      postId: POST_ID,
       commentId: 1, 
       message:'바이'
     });
 
-    expect(await caller.query('read', POST_ID_1)).toStrictEqual([
+    expect(await caller.query('read', { postId: POST_ID })).toStrictEqual([
       {
         id: 1,
         message: '바이',
-        postId: POST_ID_1
+        postId: POST_ID
       },
     ]);
 
     // mutation으로 데이터를 변경한다
     await caller.mutation('delete', {
-      postId: POST_ID_1,
+      postId: POST_ID,
       commentId: 1, 
     });
 
     // 기대하는대로 데이터가 변경되었는지, query해서 확인한다
-    expect(await caller.query('read', POST_ID_1)).toStrictEqual([]);
+    expect(await caller.query('read', { postId: POST_ID })).toStrictEqual([]);
   });
 });

--- a/back/src/comments/router.spec.ts
+++ b/back/src/comments/router.spec.ts
@@ -7,25 +7,22 @@ describe('comments', () => {
   it('scenario', async () => {
     // caller를 만들고
     const caller = commentRouter.createCaller({
-      commentRepo: FakeCommentRepo({ [POST_ID_1]: [] })
+      commentRepo: FakeCommentRepo([])
     });
-
-    await expect(() => caller.query('read', 2)).rejects.toThrowError('404');
 
     // 처음에는 id가 1인 post의 댓글 목록은 비어있다.
     expect(await caller.query('read', POST_ID_1)).toStrictEqual([]);
     // id가 1인 post의 댓글을 추가한다.
     await caller.mutation('create', {
       id: POST_ID_1,
-      comment: {
-        message: '안녕',
-      },
+      message: '안녕',
     });
     // id가 1인 post의 댓글이 추가되었다.
     expect(await caller.query('read', POST_ID_1)).toStrictEqual([
       {
         id: 1,
         message: '안녕',
+        postId: POST_ID_1
       },
     ]);
 
@@ -39,6 +36,7 @@ describe('comments', () => {
       {
         id: 1,
         message: '바이',
+        postId: POST_ID_1
       },
     ]);
 

--- a/back/src/comments/router.spec.ts
+++ b/back/src/comments/router.spec.ts
@@ -10,7 +10,7 @@ describe('comments', () => {
       commentRepo: FakeCommentRepo({ [POST_ID_1]: [] })
     });
 
-    expect(() => caller.query('read', 2)).rejects.toThrowError('404');
+    await expect(() => caller.query('read', 2)).rejects.toThrowError('404');
 
     // 처음에는 id가 1인 post의 댓글 목록은 비어있다.
     expect(await caller.query('read', POST_ID_1)).toStrictEqual([]);
@@ -33,7 +33,7 @@ describe('comments', () => {
       postId: POST_ID_1,
       commentId: 1, 
       message:'바이'
-    })
+    });
 
     expect(await caller.query('read', POST_ID_1)).toStrictEqual([
       {
@@ -46,7 +46,7 @@ describe('comments', () => {
     await caller.mutation('delete', {
       postId: POST_ID_1,
       commentId: 1, 
-    })
+    });
 
     // 기대하는대로 데이터가 변경되었는지, query해서 확인한다
     expect(await caller.query('read', POST_ID_1)).toStrictEqual([]);

--- a/back/src/comments/router.ts
+++ b/back/src/comments/router.ts
@@ -20,10 +20,10 @@ export const commentRouter = trpc
     input: z.object({
       // id: postSchema.pick({ id: true}),
       id: z.number(),
-      comment: commentSchema.omit({ id: true }),
+      message: commentSchema.shape.message,
     }),
     async resolve({ input, ctx }) {
-      void ctx.commentRepo.addCommentToPost(input.id, input.comment);
+      void ctx.commentRepo.addCommentToPost(input.id, input.message);
     },
   })
   .mutation('update', {

--- a/back/src/comments/router.ts
+++ b/back/src/comments/router.ts
@@ -23,7 +23,7 @@ export const commentRouter = trpc
       comment: commentSchema.omit({ id: true }),
     }),
     async resolve({ input, ctx }) {
-      ctx.commentRepo.addCommentToPost(input.id, input.comment);
+      void ctx.commentRepo.addCommentToPost(input.id, input.comment);
     },
   })
   .mutation('update', {
@@ -33,7 +33,7 @@ export const commentRouter = trpc
       message: z.string() 
     }),
     async resolve({ input: { postId, commentId, message }, ctx }) {
-      ctx.commentRepo.updateComment(postId, commentId, message)
+      void ctx.commentRepo.updateComment(postId, commentId, message);
     },  
   })
   .mutation('delete', {
@@ -42,6 +42,6 @@ export const commentRouter = trpc
       commentId: z.number(),
     }),
     async resolve({ input : { postId, commentId }, ctx }) {
-      ctx.commentRepo.deleteComment(postId, commentId);
+      void ctx.commentRepo.deleteComment(postId, commentId);
     },  
   });

--- a/back/src/comments/router.ts
+++ b/back/src/comments/router.ts
@@ -1,19 +1,22 @@
-import * as trpc from '@trpc/server';
 import { z } from 'zod';
-import type { CommentRepoContext } from './CommentRepoContext';
+import { createRouter } from '../createRouter';
+import { invariant } from '../invariant';
 import { commentSchema } from './schema';
 
-export const commentRouter = trpc
-  .router<CommentRepoContext>()
+export const commentRouter = createRouter()
   .query('read', {
-    // input: postSchema.pick({ id: true}),
+    // input: postSchema.pick({ id: true }),
     // postSchema의 id를 활용하는것이 목적성에 맞을까?
     // 처음에는 postSchema의 타입을 활용해야한다고 생각했는데
     // request를 보내주는것을 이미 front가 알고있기에 이렇게 사용해도 무방하다 생각되어 이렇게 작성했다.
-    input: z.number(),
+    input: z.object({
+      postId: z.number(),
+    }),
     output: z.array(commentSchema),
-    async resolve({ input, ctx }) {
-      return ctx.commentRepo.getCommentsByPostId(input);
+    async resolve({ input: { postId }, ctx }) {
+      invariant(await ctx.postRepo.has(postId), '404 not found');
+
+      return ctx.commentRepo.getCommentsByPostId(postId);
     },
   })
   .mutation('create', {
@@ -23,25 +26,31 @@ export const commentRouter = trpc
       message: commentSchema.shape.message,
     }),
     async resolve({ input, ctx }) {
-      void ctx.commentRepo.addCommentToPost(input.id, input.message);
+      invariant(await ctx.postRepo.has(input.id), '404 not found');
+
+      return ctx.commentRepo.addCommentToPost(input.id, input.message);
     },
   })
   .mutation('update', {
     input: z.object({
       postId: z.number(),
       commentId: z.number(),
-      message: z.string() 
+      message: z.string(),
     }),
     async resolve({ input: { postId, commentId, message }, ctx }) {
-      void ctx.commentRepo.updateComment(postId, commentId, message);
-    },  
+      invariant(await ctx.postRepo.has(postId), '404 not found');
+
+      return ctx.commentRepo.updateComment(postId, commentId, message);
+    },
   })
   .mutation('delete', {
     input: z.object({
       postId: z.number(),
       commentId: z.number(),
     }),
-    async resolve({ input : { postId, commentId }, ctx }) {
-      void ctx.commentRepo.deleteComment(postId, commentId);
-    },  
+    async resolve({ input: { postId, commentId }, ctx }) {
+      invariant(await ctx.postRepo.has(postId), '404 not found');
+
+      return ctx.commentRepo.deleteComment(postId, commentId);
+    },
   });

--- a/back/src/comments/schema.ts
+++ b/back/src/comments/schema.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod';
+import { postSchema } from '../posts/schema';
 
 export const commentSchema = z.object({
   id: z.number(),
   message: z.string().min(1),
+  postId: postSchema.shape.id
 });
 
 export type CommentT = z.infer<typeof commentSchema>;

--- a/back/src/createContext.ts
+++ b/back/src/createContext.ts
@@ -6,7 +6,7 @@ import { FakePostRepo } from './posts/repository';
 export type ContextT = PostRepoContext & CommentRepoContext;
 
 const postRepo = FakePostRepo([]);
-const commentRepo = FakeCommentRepo({});
+const commentRepo = FakeCommentRepo([]);
 
 export async function createContext(): Promise<ContextT> {
   return { postRepo, commentRepo };

--- a/back/src/createRouter.ts
+++ b/back/src/createRouter.ts
@@ -1,0 +1,6 @@
+import { router } from '@trpc/server';
+import { ContextT } from './createContext';
+
+export function createRouter(){
+  return router<ContextT>();
+}

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -1,4 +1,5 @@
 import * as trpc from '@trpc/server';
+import { commentRouter } from './comments/router';
 import type { ContextT } from './createContext';
 import { postRouter } from './posts/router';
 import { userRouter } from './users/user';
@@ -6,6 +7,7 @@ import { userRouter } from './users/user';
 export const appRouter = trpc
   .router<ContextT>()
   .merge('post.', postRouter)
+  .merge('comment.', commentRouter)
   .merge('user.', userRouter);
 
 export type AppRouter = typeof appRouter;

--- a/back/src/invariant.ts
+++ b/back/src/invariant.ts
@@ -1,0 +1,5 @@
+export function invariant(condition: boolean, message: string): asserts condition {
+  if(!condition){
+    throw Error(message);
+  }
+}

--- a/back/src/posts/repository.ts
+++ b/back/src/posts/repository.ts
@@ -1,6 +1,7 @@
 import type { PostT } from './schema';
 
 export interface PostRepository {
+  has: (id: PostT['id']) => Promise<boolean>;
   all: () => Promise<PostT[]>;
   add: (newPost: Omit<PostT, 'id'>) => Promise<void>;
   delete: (targetId: PostT['id']) => Promise<void>;
@@ -15,6 +16,9 @@ export function FakePostRepo(init: PostT[]): PostRepository {
   let _count = Math.max(0, ...init.map((post) => post.id));
 
   return {
+    async has(id){
+      return _fakeDB.some(post => post.id === id);
+    },
     async all() {
       return _fakeDB;
     },

--- a/back/src/posts/router.spec.ts
+++ b/back/src/posts/router.spec.ts
@@ -1,3 +1,4 @@
+import { FakeCommentRepo } from '../comments/repository';
 import { FakePostRepo } from './repository';
 import { postRouter } from './router';
 
@@ -11,6 +12,7 @@ const NEW_POST = {
 describe('posts', () => {
   it('scenario', async () => {
     const ctx = {
+      commentRepo: FakeCommentRepo([]),
       postRepo: FakePostRepo([]),
     };
     // caller를 만들고

--- a/back/src/posts/router.ts
+++ b/back/src/posts/router.ts
@@ -14,7 +14,7 @@ export const postRouter = trpc
   .mutation('create', {
     input: postSchema.omit({ id: true }),
     async resolve({ input, ctx }) {
-      ctx.postRepo.add(input);
+      void ctx.postRepo.add(input);
     },
   })
   .mutation('delete', {
@@ -22,7 +22,7 @@ export const postRouter = trpc
       targetId: z.number(),
     }),
     async resolve({ input, ctx }) {
-      ctx.postRepo.delete(input.targetId);
+      void ctx.postRepo.delete(input.targetId);
     },
   })
   .mutation('modify', {
@@ -31,6 +31,6 @@ export const postRouter = trpc
       newMessage: z.string(),
     }),
     async resolve({ input, ctx }) {
-      ctx.postRepo.modify(input);
+      void ctx.postRepo.modify(input);
     },
   });

--- a/back/src/posts/router.ts
+++ b/back/src/posts/router.ts
@@ -1,10 +1,9 @@
-import * as trpc from '@trpc/server';
-import { z } from 'zod';
-import { postSchema } from './schema';
-import type { PostRepoContext } from './PostRepoContext';
 
-export const postRouter = trpc
-  .router<PostRepoContext>()
+import { z } from 'zod';
+import { createRouter } from '../createRouter';
+import { postSchema } from './schema';
+
+export const postRouter = createRouter()
   .query('all', {
     output: z.array(postSchema),
     async resolve({ ctx }) {
@@ -14,7 +13,7 @@ export const postRouter = trpc
   .mutation('create', {
     input: postSchema.omit({ id: true }),
     async resolve({ input, ctx }) {
-      void ctx.postRepo.add(input);
+      return ctx.postRepo.add(input);
     },
   })
   .mutation('delete', {
@@ -22,7 +21,9 @@ export const postRouter = trpc
       targetId: z.number(),
     }),
     async resolve({ input, ctx }) {
-      void ctx.postRepo.delete(input.targetId);
+      await ctx.commentRepo.deleteCommentsInPost(input.targetId);
+
+      return ctx.postRepo.delete(input.targetId);
     },
   })
   .mutation('modify', {
@@ -31,6 +32,6 @@ export const postRouter = trpc
       newMessage: z.string(),
     }),
     async resolve({ input, ctx }) {
-      void ctx.postRepo.modify(input);
+      return ctx.postRepo.modify(input);
     },
   });

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -9,16 +9,16 @@ const server = fastify({
   logger: true
 });
 
-server.register(cors, {
+void server.register(cors, {
   origin: ['http://localhost:3000']
 });
 
-server.register(fastifyTRPCPlugin, {
+void server.register(fastifyTRPCPlugin, {
   prefix: '/trpc',
   trpcOptions: { router: appRouter, createContext },
 });
 
-(async () => {
+void (async () => {
   try {
     await server.listen({
       port: 5000


### PR DESCRIPTION
1. no-floating-promises 룰 적용.
2. comment repo의 인터페이스와 내부 구현을 단순하고, postRepo에 덜 의존하도록 변경.
3. post가 존재하는지 체크를 postRepo에 위임할 것.